### PR TITLE
Add support for persistent network config files

### DIFF
--- a/S39customnetwork
+++ b/S39customnetwork
@@ -34,6 +34,7 @@ copy() {
 start() {
   mount -o remount,rw /
   copy "${HOSTNAME_USER_FILE}" "${HOSTNAME_FILE}"
+  cat "${HOSTNAME_FILE}" > /proc/sys/kernel/hostname
   copy "${HOSTS_USER_FILE}" "${HOSTS_FILE}"
   copy "${DHCP_USER_FILE}" "${DHCP_FILE}"
   copy "${INTERFACES_USER_FILE}" "${INTERFACES_FILE}"

--- a/S39customnetwork
+++ b/S39customnetwork
@@ -1,0 +1,53 @@
+#!/bin/sh
+#
+# Copies available custom user network config files to the rootfs
+#
+
+USER_FOLDER="/media/fat/linux/network"
+HOSTNAME_USER_FILE="${USER_FOLDER}/hostname"
+HOSTS_USER_FILE="${USER_FOLDER}/hosts"
+DHCP_USER_FILE="${USER_FOLDER}/dhcpcd.conf"
+INTERFACES_USER_FILE="${USER_FOLDER}/interfaces"
+
+HOSTNAME_FILE="/etc/hostname"
+HOSTS_FILE="/etc/hosts"
+DHCP_FILE="/etc/dhcpcd.conf"
+INTERFACES_FILE="/etc/network/interfaces"
+
+# Copy a file if the source exists and the destination is different
+# $1 - source file
+# $2 - destination file
+copy() {
+  if [ -f "$1" ]; then
+    if [ -f "$2" ]; then
+      if cmp -s "$1" "$2"; then
+        return 0
+      else
+        cp "$1" "$2"
+      fi
+    else
+      cp "$1" "$2"
+    fi
+  fi
+}
+
+start() {
+  mount -o remount,rw /
+  copy "${HOSTNAME_USER_FILE}" "${HOSTNAME_FILE}"
+  copy "${HOSTS_USER_FILE}" "${HOSTS_FILE}"
+  copy "${DHCP_USER_FILE}" "${DHCP_FILE}"
+  copy "${INTERFACES_USER_FILE}" "${INTERFACES_FILE}"
+  mount -o remount,ro /
+}
+
+case "$1" in
+  start)
+    "$1";;
+  stop)
+    ;;
+  restart|reload)
+    start;;
+  *)
+    echo "Usage: $0 {start|stop|restart|reload}"
+    exit 1
+esac

--- a/create_img.sh
+++ b/create_img.sh
@@ -71,6 +71,8 @@ __EOF__
 echo -n $(date +%y%m%d) > ${DSTDIR}/MiSTer.version
 sed 's/#hostname/hostname/g' -i ${DSTDIR}/etc/dhcpcd.conf
 
+install -m 755 ${SRCDIR}/S39customnetwork ${DSTDIR}/etc/init.d/
+
 echo "Fixing permissions..."
 chown -R root:root ${DSTDIR} || exit 0
 sync


### PR DESCRIPTION
Hi. I want to propose this change, or something like this, to fix the long standing issue of network configurations on MiSTer not persisting through Linux updates.

This adds a new init script to the image which will copy custom network configuration files during boot before the network is started. They're copied from the linux/network directory on the SD card.

It copies these files over:
- /etc/hostname
- /etc/hosts
- /etc/dhcpcd.conf
- /etc/network/interfaces

I'm open to suggestions on alternative ways to achieve this or ways the script could be modified to work better.