### PR TITLE
Use ClientID instead of DUID in dhcpcd requests

### DIFF
--- a/create_img.sh
+++ b/create_img.sh
@@ -70,6 +70,7 @@ mount -o remount,rw /
 __EOF__
 echo -n $(date +%y%m%d) > ${DSTDIR}/MiSTer.version
 sed 's/#hostname/hostname/g' -i ${DSTDIR}/etc/dhcpcd.conf
+sed -e 's/^#clientid/clientid/' -e 's/^duid/#duid/' -i ${DSTDIR}/etc/dhcpcd.conf
 
 echo "Fixing permissions..."
 chown -R root:root ${DSTDIR} || exit 0


### PR DESCRIPTION
- With DUID, new DHCP leases would be issued upon reboot when paired with DHCP servers that respect DUID, instead of reusing the existing DHCP lease.
- The MiSTer installation process now generates a random hardware address, so DUID is unnecessary. Including DUID results in wasted leases within a DHCP scope, and can also lead to DNS resolution issues when accessing the device.
- More details
  - https://github.com/MiSTer-devel/Linux-Kernel_MiSTer/issues/29#issuecomment-1214634815
  - https://github.com/MiSTer-devel/Linux-Kernel_MiSTer/issues/29#issuecomment-1218916193
  - https://misterfpga.org/viewtopic.php?p=74311#p74311

This change has shown to be helpful for those affected by the issue. For cases where DUID is not respected by the DHCP server for DHCPv4 requests, this change has no impact.

Diff after change:
```
diff dhcpcdOLD.conf dhcpcdNEW.conf 
11c11
< #clientid
---
> clientid
16c16
< duid
---
> #duid
```